### PR TITLE
Hotfix: link to templates in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ In particular:
 - Community Health Files:
   - [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
   - [CONTRIBUTING.md](CONTRIBUTING.md)
-  - [ISSUE_TEMPLATE/BC_Break.md](ISSUE_TEMPLATE/BC_Break.md)
-  - [ISSUE_TEMPLATE/Bug.md](ISSUE_TEMPLATE/Bug.md)
-  - [ISSUE_TEMPLATE/Feature_Request.md](ISSUE_TEMPLATE/Feature_Request.md)
-  - [ISSUE_TEMPLATE/Support_Question.md](ISSUE_TEMPLATE/Support_Question.md)
-  - [PULL_REQUEST_TEMPLATE.md](PULL_REQUEST_TEMPLATE.md)
+  - [ISSUE_TEMPLATE/BC_Break.md](.github/ISSUE_TEMPLATE/BC_Break.md)
+  - [ISSUE_TEMPLATE/Bug.md](.github/ISSUE_TEMPLATE/Bug.md)
+  - [ISSUE_TEMPLATE/Feature_Request.md](.github/ISSUE_TEMPLATE/Feature_Request.md)
+  - [ISSUE_TEMPLATE/Support_Question.md](.github/ISSUE_TEMPLATE/Support_Question.md)
+  - [PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md)
   - [SECURITY.md](SECURITY.md)
   - [SUPPORT.md](SUPPORT.md)
 - Travis Build Templates:


### PR DESCRIPTION
I've updated just links but maybe also names should be changed?
