### PR TITLE
Automatic labels for distinct issue types

### DIFF
--- a/.github/ISSUE_TEMPLATE/BC_Break.md
+++ b/.github/ISSUE_TEMPLATE/BC_Break.md
@@ -1,6 +1,8 @@
 ---
 name: 💥 BC Break
 about: Have you encountered an issue during upgrade? 💣
+title: "[BC BREAK]: [DESCRIPTION]"
+labels: BC Break
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/BC_Break.md
+++ b/.github/ISSUE_TEMPLATE/BC_Break.md
@@ -1,7 +1,6 @@
 ---
 name: 💥 BC Break
 about: Have you encountered an issue during upgrade? 💣
-title: "[BC BREAK]: [DESCRIPTION]"
 labels: BC Break
 ---
 

--- a/.github/ISSUE_TEMPLATE/Bug.md
+++ b/.github/ISSUE_TEMPLATE/Bug.md
@@ -1,6 +1,7 @@
 ---
 name: 🐞 Bug Report
 about: Something is broken? 🔨
+labels: Bug
 ---
 
 ### Bug Report

--- a/.github/ISSUE_TEMPLATE/Feature_Request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.md
@@ -1,6 +1,7 @@
 ---
 name: 🎉 Feature Request
 about: You have an idea or feature that should be implemented? 🎩
+labels: Enhancement
 ---
 
 ### Feature Request


### PR DESCRIPTION
Following the new RFC template, this patch adds labels (and in one case, a title) for the discrete types:

- BC Break: gets the BC Break label, and a title that also calls attention to it.
- Bug: gets the Bug label.
- Feature Request: gets the Enhancement label.

