### PR TITLE
Use Renovate's sign-off preset

### DIFF
--- a/RENOVATE.md
+++ b/RENOVATE.md
@@ -58,6 +58,7 @@ possible presets have been chosen.
     ":combinePatchMinorReleases",
     ":enableVulnerabilityAlerts",
     ":timezone(UTC)",
+    ":gitSignOff",
     ":label(renovate)",
     "group:allNonMajor",
     "schedule:daily",
@@ -86,6 +87,7 @@ minor releases for a single package will be combined to a single update.
 should the repository have any vulnerability alerts (see below).
 **[:timezone(UTC)](https://docs.renovatebot.com/presets-default/#timezonearg0)** - Not strictly necessary but ensures
 schedules use the UTC timezone.
+**[:gitSignOff](https://docs.renovatebot.com/presets-default/#gitsignoff)** - DCO requires all commits to be signed off.
 **[:label(renovate)](https://docs.renovatebot.com/presets-default/#labelarg0)** - Add the label `renovate` to any PRs.
 **[group:allNonMajor](https://docs.renovatebot.com/presets-group/#groupallnonmajor)** - Any non-major updates will be
 grouped into a single update.
@@ -111,7 +113,6 @@ From https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts:
 ### Other Settings
 
 ```json
-"commitMessageSuffix": "\n\nSigned-off-by: Renovate Bot <bot@renovateapp.com>",
 "enabledManagers": ["composer", "dockerfile", "docker-compose", "github-actions"],
 "lockFileMaintenance": {"enabled": true, "extends": ["schedule:daily"]},
 "platformAutomerge": true,
@@ -120,7 +121,6 @@ From https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts:
 "rollbackPrs": true,
 ```
 
-**[commitMessageSuffix](https://docs.renovatebot.com/configuration-options/#commitmessagesuffix)** - DCO requires all commits to be signed off.
 **[enabledManagers](https://docs.renovatebot.com/configuration-options/#enabledmanagers)** - To begin with, this is
 enabled for `composer`, `dockerfile`, `docker-compose` and `github-actions`. Other managers (such as `npm` etc) are also
 available.

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -13,11 +13,11 @@
         ":combinePatchMinorReleases",
         ":enableVulnerabilityAlerts",
         ":timezone(UTC)",
+        ":gitSignOff",
         ":label(renovate)",
         "group:allNonMajor",
         "schedule:daily"
     ],
-    "commitMessageSuffix": "\n\nSigned-off-by: Renovate Bot <bot@renovateapp.com>",
     "enabledManagers": ["composer", "dockerfile", "docker-compose", "github-actions"],
     "lockFileMaintenance": {"enabled": true, "extends": ["schedule:daily"]},
     "platformAutomerge": true,


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

I found a better way to implement https://github.com/laminas/.github/pull/21. Renovate includes a feature to sign off commits. This should prevent the `Dependency Dashboard` descriptions from containing the sign off message.

Apologies that I missed this first time around, it was an oversight on my part. It's late and this is clearly a sign I should go to sleep.