### PR TITLE
Add an update description table to commit messages

### DIFF
--- a/RENOVATE.md
+++ b/RENOVATE.md
@@ -110,6 +110,7 @@ From https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts:
 ### Other Settings
 
 ```json
+"commitBodyTable": true,
 "enabledManagers": ["composer", "dockerfile", "docker-compose", "github-actions"],
 "lockFileMaintenance": {"enabled": true, "extends": ["schedule:daily"]},
 "platformAutomerge": true,
@@ -118,6 +119,8 @@ From https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts:
 "rollbackPrs": true,
 ```
 
+**[commitBodyTable](https://docs.renovatebot.com/configuration-options/#commitbodytable)** - Adds a table to the commit
+message describing all updates in the commit.
 **[enabledManagers](https://docs.renovatebot.com/configuration-options/#enabledmanagers)** - To begin with, this is
 enabled for `composer`, `dockerfile`, `docker-compose` and `github-actions`. Other managers (such as `npm` etc) are also
 available.

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -17,6 +17,7 @@
         "group:allNonMajor",
         "schedule:daily"
     ],
+    "commitBodyTable": true,
     "enabledManagers": ["composer", "dockerfile", "docker-compose", "github-actions"],
     "lockFileMaintenance": {"enabled": true, "extends": ["schedule:daily"]},
     "platformAutomerge": true,


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Adds the following configuration option [`commitBodyTable`](https://docs.renovatebot.com/configuration-options/#commitbodytable) and sets it to true.