### PR TITLE
Remove `master` branch references from docs, point contributors at current/stable release branches

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,10 @@
 Fill in the relevant information below to help triage your issue.
 
 Pick the target branch based on the following criteria:
-  * Documentation improvement: master branch
-  * Bugfix: master branch
+  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
+  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
   * QA improvement (additional tests, CS fixes, etc.) that does not change code
-    behavior: master branch
+    behavior: default X.Y.z branch or the oldest support X.Y.z
   * New feature, or refactor of existing code: develop branch
 
 You MUST provide a signoff in your commits for us to be able to accept your
@@ -31,21 +31,21 @@ Tell us about why this change is necessary:
   - How do you reproduce it?
   - What did you expect to happen?
   - What actually happened?
-  - TARGET THE master BRANCH
+  - TARGET THE default X.Y.z branch or the oldest support X.Y.z
 
 - Are you adding documentation?
-  - TARGET THE master BRANCH
+  - TARGET THE default X.Y.z branch or the oldest support X.Y.z
 
 - Are you providing a QA improvement (additional tests, CS fixes, etc.) that
   does not change behavior?
   - Explain why the changes are necessary
-  - TARGET THE master BRANCH
+  - TARGET THE default X.Y.z branch or the oldest support X.Y.z
 
 - Are you fixing a BC Break?
   - How do you reproduce it?
   - What was the previous behavior?
   - What is the current behavior?
-  - TARGET THE master BRANCH
+  - TARGET THE default X.Y.z branch or the oldest support X.Y.z
 
 - Are you adding something the library currently does not support?
   - Why should it be added?


### PR DESCRIPTION
Rename the master references to current branch

Closes #14

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
