### PR TITLE
Updated DCO configuration

### DIFF
--- a/dco.yml
+++ b/dco.yml
@@ -1,0 +1,5 @@
+allowRemediationCommits:
+  individual: true
+  thirdParty: true
+require:
+  members: false


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description

The configuration presented here does the following:

- Allows a contributor to push a signed commit as the last commit to a PR to remediate DCO.
  As such, they won't need to do a `rebase --signoff` + `push -f`; they'd just push the last commit up to their branch.
- Allows a third-party with commit access (i.e., maintainers) to push a signed commit to a contributor's branch in order to sign-off for them.
  This works in the same way as the above.
- Makes it so organization members do NOT need to sign off on commits; the assumption is that by being members, they have already signed off on DCO.
