### PR TITLE
Ensure lock file maintenance waits for status checks to complete

### DIFF
--- a/RENOVATE.md
+++ b/RENOVATE.md
@@ -51,7 +51,6 @@ possible presets have been chosen.
     ":ignoreModulesAndTests",
     ":automergeMinor",
     ":automergeBranch",
-    ":prNotPending",
     ":rebaseStalePrs",
     ":semanticCommitsDisabled",
     ":separateMajorReleases",
@@ -72,8 +71,6 @@ Renovate does not try to update `composer.json` inside `tests/`, `vendor/` etc.
 updates of updates by default.
 - **[:automergeBranch](https://docs.renovatebot.com/presets-default/#automergebranch)** - But set the default automatic
 merge type to be `branch` meaning a PR is only opened on failure.
-- **[:prNotPending](https://docs.renovatebot.com/presets-default/#prnotpending)** - PRs will also only be created AFTER
-all checks have finished running.
 - **[:rebaseStalePrs](https://docs.renovatebot.com/presets-default/#rebasestaleprs)** - Any PRs previously opened by
 Renovate will be automatically rebased should they fall behind.
 - **[:semanticCommitsDisabled](https://docs.renovatebot.com/presets-default/#semanticcommitsdisabled) - Disable semantic

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -6,7 +6,6 @@
         ":ignoreModulesAndTests",
         ":automergeMinor",
         ":automergeBranch",
-        ":prNotPending",
         ":rebaseStalePrs",
         ":semanticCommitsDisabled",
         ":separateMajorReleases",


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

As seen with https://github.com/laminas/laminas-cache-storage-adapter-session/pull/23, renovate is creating PRs and then merging them even when the CI checks pass. The intention of this configuration however, is to create PRs only when updates cause CI checks to fail, including lock file maintenance.

After reviewing the logs for this run at https://app.renovatebot.com/dashboard#github/laminas/laminas-cache-storage-adapter-session/804282055, it appears that the PR is being created BEFORE waiting for the CI checks to complete. This PR should ensure the intended behaviour also applies to lock file maintenance.

Edit: I'm not convinced this should be necessary as this issue suggests the opposite should be true:
- https://github.com/renovatebot/renovate/issues/17332