### PR TITLE
Revert "Bump `require-dev` instead of `replace`"

### DIFF
--- a/RENOVATE.md
+++ b/RENOVATE.md
@@ -155,9 +155,8 @@ alerts, enabled by a previous preset, will use a `rangeStrategy` of `update-lock
 ```
 
 The first of these package rules will ensure that non-development dependency version constraints are widened when a
-newer version is available outside them. Widening the range of a development dependency makes little sense, so the bump
-strategy is used by default to ensure that development dependencies are kept at the most recent possible minor or patch versions.
- - `bump` Update the range for every release, e.g. `^1.2.3` -> `^1.2.4`.
+newer version is available outside them. Widening the range of a development dependency makes little sense.
+ - `replace` Replace the range with a newer one if the new version falls outside it, and update nothing otherwise.
  - `widen` Widen the range with newer one, e.g. `^1.0.0` -> `^1.0.0 || ^2.0.0`.
 
 Although not necessary, this will group updates from each of these organizations into a single update. Combined with the

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -20,7 +20,7 @@
     "lockFileMaintenance": {"enabled": true, "extends": ["schedule:daily"]},
     "platformAutomerge": true,
     "prFooter": "[Read more information](https://github.com/laminas/.github/blob/main/RENOVATE.md) about the use of [Renovate Bot](https://github.com/renovatebot/renovate) within Laminas.",
-    "rangeStrategy": "bump",
+    "rangeStrategy": "replace",
     "rollbackPrs": true,
     "packageRules": [
         {"matchDepTypes": ["require"], "rangeStrategy": "widen"},


### PR DESCRIPTION
Reverts #39
Fixes #41 

As discussed in #41, the `bump` strategy is **NOT** what we initially thought, and is mostly a world of pain for our current development approach.

We will either re-introduce a bump once we have something compatible, or we will attempt contributing a compatible strategy to upstream @renovate-bot. 