### PR TITLE
Change lockfile maintenance schedule to weekly

### DIFF
--- a/RENOVATE.md
+++ b/RENOVATE.md
@@ -110,7 +110,7 @@ From https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts:
 
 ```json
 "commitBodyTable": true,
-"lockFileMaintenance": {"enabled": true, "extends": ["schedule:daily"]},
+"lockFileMaintenance": {"enabled": true, "extends": ["schedule:weekly"]},
 "platformAutomerge": true,
 "prFooter": "[Read more information](https://github.com/laminas/.github/blob/main/RENOVATE.md) about the use of [Renovate Bot](https://github.com/renovatebot/renovate) within Laminas.",
 "rangeStrategy": "replace",

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -17,7 +17,7 @@
         "group:allNonMajor"
     ],
     "commitBodyTable": true,
-    "lockFileMaintenance": {"enabled": true, "extends": ["schedule:daily"]},
+    "lockFileMaintenance": {"enabled": true, "extends": ["schedule:weekly"]},
     "platformAutomerge": true,
     "prFooter": "[Read more information](https://github.com/laminas/.github/blob/main/RENOVATE.md) about the use of [Renovate Bot](https://github.com/renovatebot/renovate) within Laminas.",
     "rangeStrategy": "replace",


### PR DESCRIPTION
This was mentioned in slack in the last TSC meeting, but I'm not sure if a vote is required for this change.

Weekly lock-file maintenance will reduce the commit log noise and volume of maintainer notifications with any luck 🤞